### PR TITLE
Increase the timeout of CAPI Chunk's Future from 10 to 20 seconds

### DIFF
--- a/src/java/org/apache/cassandra/cache/capi/CapiChunkDriver.java
+++ b/src/java/org/apache/cassandra/cache/capi/CapiChunkDriver.java
@@ -82,7 +82,7 @@ public class CapiChunkDriver extends PersistenceDriverImpl implements Persistenc
                     throw new IllegalStateException();
 
                 long start = System.currentTimeMillis();
-                while ((rc = future.get(10L, TimeUnit.SECONDS)) == 0L)
+                while ((rc = future.get(20L, TimeUnit.SECONDS)) == 0L)
                     ;
                 long elapsed = System.currentTimeMillis() - start;
 


### PR DESCRIPTION
To avoid "java.util.concurrent.TimeoutException: Future timed out" when running with OpenJDK, need to increase the timeout to 20 seconds.
