### PR TITLE
Cassandra 2.1 capirowcache

### DIFF
--- a/src/java/org/apache/cassandra/cache/capi/CapiCache.java
+++ b/src/java/org/apache/cassandra/cache/capi/CapiCache.java
@@ -380,11 +380,13 @@ public class CapiCache<K, V> {
                 for (PersistenceDriver driver : drivers)
                     driver.process();
             synchronized (ret) {
-                try {
-                    ret.wait();
-                } catch (InterruptedException ex) {
-                    throw new IllegalStateException(ex);
-                }
+            	if (ret.get() == null) {
+            		try {
+            			ret.wait();
+            		} catch (InterruptedException ex) {
+            			throw new IllegalStateException(ex);
+            		}
+            	}
             }
         }
 


### PR DESCRIPTION
If another thread calls ret.set() and ret.notify() while this thread is running between the check of ret.get() == null and the next synchronized block, this thread will wait at ret.wait() forever without being notified. This pull request will add an additional check in the synchronized block to avoid the race condition.
